### PR TITLE
Android: Implement BLE Name Exchange Using BLE Read Descriptors

### DIFF
--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/utils/Constants.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/utils/Constants.kt
@@ -37,6 +37,7 @@ class Constants{
 
         val TINYSSB_BLE_REPL_SERVICE_2022 = UUID.fromString("6e400001-7646-4b5b-9a50-71becce51558")
         val TINYSSB_BLE_RX_CHARACTERISTIC = UUID.fromString("6e400002-7646-4b5b-9a50-71becce51558") // for writing to the remote device
+        val TINYSSB_BLE_RX_NAME_DESCRIPTOR = UUID.fromString("6e400002-7646-4b5b-9a50-71becce51559")
         val TINYSSB_BLE_TX_CHARACTERISTIC = UUID.fromString("6e400003-7646-4b5b-9a50-71becce51558") // for receiving from the remote device
 
         val TINYSSB_SIMPLEPUB_URL = "ws://meet.dmi.unibas.ch:8080"


### PR DESCRIPTION
## What?

The full public key is now exchanged via a Bluetooth Low Energy (BLE) descriptor, replacing the previous method of using an 8-character hash in the device name field of a BLE advertisement packet.

## Why?

Previously, the name of the Bluetooth adapter was changed to an 8-character hash of the user's public key. This enabled other peers to identify the device by the name given in the advertisement messages. However, modifying the Bluetooth adapter name also changes the name for other Bluetooth applications. \
Therefore, a new mechanism has been developed to share the device's public key with other peers without changing the Bluetooth name for other applications on the same device.

## How?

The public key is offered via a BLE descriptor. Once a peer established a BLE connection, it can read this descriptor to obtain the public key of the other device.

## Testing

Tested with two android smartphones (SDK 29 & 30).

## Anything Else?

Older versions of the app do not read this descriptor and therefore can't get the public key of the other device. This will only affect the list of connected devices in the frontend.
