### PR TITLE
android: add additional frontend callbacks for received log entries

### DIFF
--- a/android/tinySSB/app/src/main/assets/web/tremola.js
+++ b/android/tinySSB/app/src/main/assets/web/tremola.js
@@ -981,22 +981,46 @@ function b2f_local_peer(type, identifier, displayname, status) {
 
 /**
  * This function is called, when the backend received a new log entry and successfully completed the corresponding sidechain.
- * The backend assures, that the log entries are sent to the frontend in the same sequential order as in the append-only log.
+ * The backend assures, that the log entries are sent to the frontend in the exact same sequential order as in the append-only log.
  *
  * @param {Object} e     Object containing all information of the log_entry.
- * @param {Object} e.hdr Contains basic information about the log entry.{tst: 1700234500672, ref: 417869, fid: '@AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=.ed25519'}
+ * @param {Object} e.hdr Contains basic information about the log entry.
  * @param {number} e.hdr.tst Timestamp at which the message was created. (Number of milliseconds elapsed since midnight at the beginning of January 1970 00:00 UTC)
  * @param {string} e.hdr.ref The message ID of this log entry.
  * @param {string} e.hdr.fid The public key of the author encoded in base64.
  * @param {[]} e.public The payload of the message
  *
  */
+
 function b2f_new_in_order_event(e) {
 }
 
+/**
+ * This function is invoked whenever the backend receives a new log entry, regardless of whether the associated sidechain is fully loaded or not.
+ *
+ * @param {Object} e     Object containing all information of the log_entry.
+ * @param {Object} e.hdr Contains basic information about the log entry.
+ * @param {number} e.hdr.tst Timestamp at which the message was created. (Number of milliseconds elapsed since midnight at the beginning of January 1970 00:00 UTC)
+ * @param {string} e.hdr.ref The message ID of this log entry.
+ * @param {string} e.hdr.fid The public key of the author encoded in base64.
+ * @param {[]} e.public The payload of the logentry, without the content of the sidechain
+ *
+ */
 function b2f_new_incomplete_event(e) {
 }
 
+/**
+ * This function is called, when the backend received a new log entry and successfully completed the corresponding sidechain.
+ * This callback does not ensure any specific order; the log entries are forwarded in the order they are received.
+ *
+ * @param {Object} e     Object containing all information of the log_entry.
+ * @param {Object} e.hdr Contains basic information about the log entry.
+ * @param {number} e.hdr.tst Timestamp at which the message was created. (Number of milliseconds elapsed since midnight at the beginning of January 1970 00:00 UTC)
+ * @param {string} e.hdr.ref The message ID of this log entry.
+ * @param {string} e.hdr.fid The public key of the author encoded in base64.
+ * @param {[]} e.public The payload of the message
+ *
+ */
 function b2f_new_event(e) { // incoming SSB log event: we get map with three entries
                             // console.log('hdr', JSON.stringify(e.header))
     console.log('pub', JSON.stringify(e.public))

--- a/android/tinySSB/app/src/main/assets/web/tremola.js
+++ b/android/tinySSB/app/src/main/assets/web/tremola.js
@@ -993,7 +993,7 @@ function b2f_local_peer(type, identifier, displayname, status) {
  */
 function b2f_new_in_order_event(e) {
 
-    console.log("b2f inorder event")
+    console.log("b2f inorder event:", JSON.stringify(e.public))
 
     if (!(e.header.fid in tremola.contacts)) {
         var a = id2b32(e.header.fid);

--- a/android/tinySSB/app/src/main/assets/web/tremola.js
+++ b/android/tinySSB/app/src/main/assets/web/tremola.js
@@ -979,6 +979,24 @@ function b2f_local_peer(type, identifier, displayname, status) {
         refresh_connection_entry(identifier)
 }
 
+/**
+ * This function is called, when the backend received a new log entry and successfully completed the corresponding sidechain.
+ * The backend assures, that the log entries are sent to the frontend in the same sequential order as in the append-only log.
+ *
+ * @param {Object} e     Object containing all information of the log_entry.
+ * @param {Object} e.hdr Contains basic information about the log entry.{tst: 1700234500672, ref: 417869, fid: '@AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=.ed25519'}
+ * @param {number} e.hdr.tst Timestamp at which the message was created. (Number of milliseconds elapsed since midnight at the beginning of January 1970 00:00 UTC)
+ * @param {string} e.hdr.ref The message ID of this log entry.
+ * @param {string} e.hdr.fid The public key of the author encoded in base64.
+ * @param {[]} e.public The payload of the message
+ *
+ */
+function b2f_new_in_order_event(e) {
+}
+
+function b2f_new_incomplete_event(e) {
+}
+
 function b2f_new_event(e) { // incoming SSB log event: we get map with three entries
                             // console.log('hdr', JSON.stringify(e.header))
     console.log('pub', JSON.stringify(e.public))

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/MainActivity.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/MainActivity.kt
@@ -91,20 +91,11 @@ class MainActivity : Activity() {
 
         Log.d("IDENTITY", "is ${idStore.identity.toRef()} (${idStore.identity.verifyKey})")
 
-        //val dict = mutableMapOf<String,Any>()
-        //dict["test1"] = 1000
-        //dict["test2"] = 248
-        //Log.d("DICT TEST", "res: ${Bipf.bipf_loads(Bipf.encode(Bipf.mkDict(dict))!!)!!.get()}")
-
-        Log.d("INT TEST", "res: ${Bipf.bipf_loads(Bipf.encode(Bipf.mkInt(250))!!)!!.getInt()}")
         val webView = findViewById<WebView>(R.id.webView)
         wai = WebAppInterface(this, webView)
         tinyIO = IO(this, wai)
         tinyGoset._include_key(idStore.identity.verifyKey) // make sure our local key is in
         tinyRepo.load()
-        //for (f in tinyRepo.listFeeds()) {
-        //    tinyGoset._include_key(f)
-        //}
         tinyGoset.adjust_state()
         tinyDemux.arm_dmx(tinyGoset.goset_dmx,  {buf:ByteArray, aux:ByteArray?, _ -> tinyGoset.rx(buf,aux)}, null)
         tinyDemux.arm_dmx(tinyDemux.want_dmx!!, {buf:ByteArray, aux:ByteArray?, sender:String? -> tinyNode.incoming_want_request(buf,aux,sender)})

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/MainActivity.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/MainActivity.kt
@@ -80,6 +80,9 @@ class MainActivity : Activity() {
         // tremolaState = TremolaState(this)
         idStore = IdStore(this)
 
+        // upgrades repo filesystem if necessary
+        tinyRepo.upgrade_repo()
+
 
         // wifiManager = applicationContext.getSystemService(WIFI_SERVICE) as WifiManager
         // mlock = wifiManager?.createMulticastLock("lock")

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/MainActivity.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/MainActivity.kt
@@ -24,6 +24,7 @@ import nz.scuttlebutt.tremolavossbol.crypto.IdStore
 import nz.scuttlebutt.tremolavossbol.tssb.ble.BlePeers
 import nz.scuttlebutt.tremolavossbol.tssb.*
 import nz.scuttlebutt.tremolavossbol.tssb.ble.BluetoothEventListener
+import nz.scuttlebutt.tremolavossbol.utils.Bipf
 import nz.scuttlebutt.tremolavossbol.utils.Constants
 import tremolavossbol.R
 import java.net.*
@@ -85,13 +86,23 @@ class MainActivity : Activity() {
         // if (!mlock!!.isHeld) mlock!!.acquire()
         // mkSockets()
 
-        Log.d("IDENTITY", "is ${idStore.identity.toRef()}")
+        Log.d("IDENTITY", "is ${idStore.identity.toRef()} (${idStore.identity.verifyKey})")
 
+        //val dict = mutableMapOf<String,Any>()
+        //dict["test1"] = 1000
+        //dict["test2"] = 248
+        //Log.d("DICT TEST", "res: ${Bipf.bipf_loads(Bipf.encode(Bipf.mkDict(dict))!!)!!.get()}")
+
+        Log.d("INT TEST", "res: ${Bipf.bipf_loads(Bipf.encode(Bipf.mkInt(250))!!)!!.getInt()}")
         val webView = findViewById<WebView>(R.id.webView)
         wai = WebAppInterface(this, webView)
         tinyIO = IO(this, wai)
         tinyGoset._include_key(idStore.identity.verifyKey) // make sure our local key is in
-        tinyRepo.repo_load()
+        tinyRepo.load()
+        //for (f in tinyRepo.listFeeds()) {
+        //    tinyGoset._include_key(f)
+        //}
+        tinyGoset.adjust_state()
         tinyDemux.arm_dmx(tinyGoset.goset_dmx,  {buf:ByteArray, aux:ByteArray?, _ -> tinyGoset.rx(buf,aux)}, null)
         tinyDemux.arm_dmx(tinyDemux.want_dmx!!, {buf:ByteArray, aux:ByteArray?, sender:String? -> tinyNode.incoming_want_request(buf,aux,sender)})
         tinyDemux.arm_dmx(tinyDemux.chnk_dmx!!, { buf:ByteArray, aux:ByteArray?, _ -> tinyNode.incoming_chunk_request(buf,aux)})

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/Settings.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/Settings.kt
@@ -9,7 +9,7 @@ import java.io.File
 class Settings(val context: MainActivity) {
     private val sharedPreferences = context.getSharedPreferences("tinyssbSettings", Context.MODE_PRIVATE)
 
-    private val WEBSOCKET_ENABLED_BY_DEFAULT = true
+    private val WEBSOCKET_ENABLED_BY_DEFAULT = false
     private val BLE_ENABLED_BY_DEFAULT = true
     private val UDP_MULTICAST_ENABLED_BY_DEFAULT = true
 

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
@@ -368,7 +368,7 @@ class WebAppInterface(val act: MainActivity, val webView: WebView) {
         // in-order api
         val replica = act.tinyRepo.fid2replica(fid)
 
-        if (frontend_frontier.getInt(fid.toHex(), 0) == seq && replica != null) {
+        if (frontend_frontier.getInt(fid.toHex(), 1) == seq && replica != null) {
             for (i in seq .. replica.state.max_seq ) {
                 val content = replica.read(i)
                 val message_id= replica.get_mid(seq)

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
@@ -372,7 +372,7 @@ class WebAppInterface(val act: MainActivity, val webView: WebView) {
             for (i in seq .. replica.state.max_seq ) {
                 val content = replica.read(i)
                 val message_id= replica.get_mid(seq)
-                if(content == null || message_id == null)
+                if(content == null || message_id == null || !replica.isSidechainComplete(i))
                     break
                 e = toFrontendObject(fid, i, message_id, content)
                 if (e != null)

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
@@ -31,7 +31,7 @@ import org.json.JSONArray
 class WebAppInterface(val act: MainActivity, val webView: WebView) {
 
     var frontend_ready = false
-    private val frontend_frontier = act.getSharedPreferences("frontend_frontier", Context.MODE_PRIVATE)
+    val frontend_frontier = act.getSharedPreferences("frontend_frontier", Context.MODE_PRIVATE)
 
     @JavascriptInterface
     fun onFrontendRequest(s: String) {
@@ -350,6 +350,13 @@ class WebAppInterface(val act: MainActivity, val webView: WebView) {
         var cmd = "b2f_new_voice('" + voice.toBase64() + "');"
         Log.d("CMD", cmd)
         eval(cmd)
+    }
+
+    fun sendIncompleteEntryToFrontend(fid: ByteArray, seq: Int, mid:ByteArray, body: ByteArray) {
+        val e = toFrontendObject(fid, seq, mid, body)
+        if (e != null)
+            eval("b2f_new_incomplete_event($e)")
+
     }
 
     fun sendTinyEventToFrontend(fid: ByteArray, seq: Int, mid:ByteArray, body: ByteArray) {

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
@@ -59,7 +59,7 @@ class WebAppInterface(val act: MainActivity, val webView: WebView) {
                         val r = act.tinyRepo.fid2replica(fid)
                         if(r == null)
                             break
-                        val payload = r.read(i)
+                        val payload = r.read_content(i)
                         val mid = r.get_mid(i)
                         if (payload == null || mid == null) break
                         Log.d("restream", "${i}, ${payload.size} Bytes")

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
@@ -370,7 +370,7 @@ class WebAppInterface(val act: MainActivity, val webView: WebView) {
 
         if (frontend_frontier.getInt(fid.toHex(), 1) == seq && replica != null) {
             for (i in seq .. replica.state.max_seq ) {
-                val content = replica.read(i)
+                val content = replica.read_content(i)
                 val message_id= replica.get_mid(seq)
                 if(content == null || message_id == null || !replica.isSidechainComplete(i))
                     break

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/crypto/IdStore.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/crypto/IdStore.kt
@@ -28,7 +28,7 @@ class IdStore(val context: MainActivity) {
         val fdir = File(context.getDir(Constants.TINYSSB_DIR, Context.MODE_PRIVATE), context.tinyRepo.FEED_DIR)
         if (!File(fdir, "${identity.verifyKey.toHex()}").exists()) {
             Log.d("idstore","create new feed repo")
-            context.tinyRepo.new_feed(identity.verifyKey)
+            context.tinyRepo.add_replica(identity.verifyKey)
         } else
             Log.d("idstore","no need to create new feed repo")
     }

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/GOset.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/GOset.kt
@@ -228,7 +228,7 @@ class GOset(val context: MainActivity) {
     fun _add_key(key: ByteArray) {
         if (!_include_key(key)) // adds key if necessary
             return
-        context.tinyRepo.new_feed(key)
+        context.tinyRepo.add_replica(key)
 
         keys.sortWith({a:ByteArray,b:ByteArray -> byteArrayCmp(a,b)})
         if (keys.size >= largest_claim_span) { // only rebroadcast if we are up to date

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Node.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Node.kt
@@ -86,7 +86,6 @@ class Node(val context: MainActivity) {
         }
         var v= "CHNK vector=["
         var credit = 3
-        Log.d("in_chnk", "outer")
         for (e in vect.getBipfList()) {
             val fNDX: Int
             val fid: ByteArray
@@ -136,22 +135,6 @@ class Node(val context: MainActivity) {
 
         Log.d("node", "beacon")
 
-        /*val l = arrayListOf<Any>()
-        val c = arrayListOf<Any>(1, "ok", 2)
-        l.add(c)
-
-        val b = Bipf.bipf_loads(Bipf.encode(Bipf.mk(l))!!)!!
-
-        val lst = b.getBipfList()[0].getBipfList()
-
-        val first = lst[0].get()
-        val sec = lst[1].get()
-        val third = lst[2].get()
-
-        Log.d("Test", "$first, $sec, $third")
-
-
-        return*/
         val want_buf = context.tinyRepo.mk_want_vect()
         if (want_buf != null)
             context.tinyIO.enqueue(want_buf, context.tinyDemux.want_dmx)

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Node.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Node.kt
@@ -159,8 +159,6 @@ class Node(val context: MainActivity) {
         val chnk_buf = context.tinyRepo.mk_chnk_vect()
         if (chnk_buf != null)
             context.tinyIO.enqueue(chnk_buf, context.tinyDemux.chnk_dmx)
-
-        // TODO update_progress(vector.toSortedMap().values.toList(), "me")
     }
 
     fun incoming_pkt(buf: ByteArray, fid: ByteArray) {

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Node.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Node.kt
@@ -32,7 +32,7 @@ class Node(val context: MainActivity) {
         Log.d("node", "incoming WANT ${buf.toHex()} from sender: $sender")
         val vect = bipf_loads(buf.sliceArray(DMX_LEN..buf.lastIndex))
         if (vect == null || vect.typ != BIPF_LIST) return
-        val lst = vect.getList()
+        val lst = vect.getBipfList()
         if (lst.size < 1 || lst[0].typ != BIPF_INT) {
             Log.d("node", "incoming WANT error with offset")
             return
@@ -57,9 +57,13 @@ class Node(val context: MainActivity) {
             // Log.d("node", "want ${fid.toHex()}.${seq}")
             while (credit > 0) {
                 val pkt = context.tinyRepo.feed_read_pkt(fid, seq)
-                if (pkt == null)
+                //Log.d("incoming_want", "read pkt ${fid.toHex()}.$seq")
+                if (pkt == null) {
+                    //Log.d("incoming_want", "pkt not found")
                     break
-                Log.d("node", "  have entry ${fid.toHex()}.${seq}")
+                }
+
+                Log.d("node", "  have entry ${fid.toHex()}.${seq} with dmx: ${pkt.sliceArray(0 until DMX_LEN).toHex()} (len: ${pkt.size})")
                 context.tinyIO.enqueue(pkt)
                 seq++;
                 credit--;
@@ -82,13 +86,15 @@ class Node(val context: MainActivity) {
         }
         var v= "CHNK vector=["
         var credit = 3
-        for (e in vect.getList()) {
+        Log.d("in_chnk", "outer")
+        for (e in vect.getBipfList()) {
             val fNDX: Int
             val fid: ByteArray
             val seq: Int
             var cnr: Int
             try {
-                val lst = e.getList()
+                Log.d("in_chnk", "inner")
+                val lst = e.getBipfList()
                 fNDX = lst[0].getInt()
                 fid = context.tinyGoset.keys[fNDX]
                 seq = lst[1].getInt()
@@ -127,141 +133,57 @@ class Node(val context: MainActivity) {
     }
 
     fun beacon() { // called in regular intervals
-        /*
-        Serial.print("|dmxt|=" + String(dmxt_cnt) + ", |chkt|=" + String(blbt_cnt));
-        int fcnt, ecnt, bcnt;
-        stats(&fcnt, &ecnt, &bcnt);
-        */
-        Log.d("node", "beacon") // , stats: |feeds|=" + String(fcnt) + ", |entries|=" + String(ecnt) + ", |blobs|=" + String(bcnt));
 
-        var v = ""
-        val vect = Bipf.mkList()
-        var vector = mutableMapOf<Int, Int>() // want vector for frontend
-        var encoding_len = 0
-        log_offs = (log_offs + 1) % context.tinyGoset.keys.size
-        Bipf.list_append(vect, Bipf.mkInt(log_offs))
-        var i = 0
-        while (i < context.tinyGoset.keys.size) {
-            val ndx = (log_offs + i) % context.tinyGoset.keys.size
-            val key = context.tinyGoset.keys[ndx]
-            val feed = context.tinyRepo.feeds[context.tinyRepo._feed_index(key)]
-            val bptr = Bipf.mkInt(feed.next_seq)
-            Bipf.list_append(vect, bptr)
-            val dmx = context.tinyDemux.compute_dmx(key + feed.next_seq.toByteArray()
-                    + feed.prev_hash)
-            // Log.d("node", "dmx is ${dmx.toHex()}")
-            val fct = { buf:ByteArray, fid:ByteArray?, _:String? -> context.tinyNode.incoming_pkt(buf, fid!!) }
-            context.tinyDemux.arm_dmx(dmx, fct, key)
-            v += (if (v.length == 0) "[ " else ", ") + "$ndx.${feed.next_seq}"
-            vector[ndx] = feed.next_seq
-            i++
-            encoding_len += Bipf.encode(bptr)!!.size
-            if (encoding_len > 100)
-                break
-        }
-        log_offs = (log_offs + i) % context.tinyGoset.keys.size
-        if (vect.cnt > 1) {  // vect always has at least offs plus one element ?!
-            val buf = Bipf.encode(vect)
-            if (buf != null) {
-                context.tinyIO.enqueue(buf, context.tinyDemux.want_dmx)
-                Log.d("node", ">> sent WANT request ${v} ]")
-                update_progress(vector.toSortedMap().values.toList(), "me")
-            }
-        }
+        Log.d("node", "beacon")
 
-        // hunt for unfinished sidechains
-        // FIXME: limit vector to 100B, rotate through set
-        v = ""
-        val chunkReqList = Bipf.mkList()
-        val fdir = File(context.getDir(Constants.TINYSSB_DIR, Context.MODE_PRIVATE), context.tinyRepo.FEED_DIR)
-        val r = context.tinyRepo
-        for (f in fdir.listFiles()) {
-            if (!f.isDirectory || f.name.length != 2* Constants.FID_LEN) continue
-            val fid = f.name.decodeHex()
-            val frec = context.tinyRepo.fid2rec(fid, true)
-            frec!!.next_seq = r.feed_len(fid) + 1
-            for (fn in f.listFiles()) {
-                if (fn.name[0] != '!')
-                    continue
-                var seq = fn.name.substring(1..fn.name.lastIndex).toInt()
-                val sz = fn.length().toInt()
-                var h = ByteArray(HASH_LEN)
-                Log.d("node","need chunk ${fid.toHex().substring(0..19)}.${seq}")
-                if (sz == 0) { // must fetch first ptr from log
-                    val pkt = r.feed_read_pkt(fid, seq)
-                    if (pkt != null) {
-                        h = pkt.sliceArray(DMX_LEN + 1 + 28..DMX_LEN + 1 + 28 + HASH_LEN - 1)
-                        Log.d("node","  having hash ${h.toHex()}")
-                    } else {
-                        Log.d("node", "  failed to find hash")
-                        seq = -1
-                    }
+        /*val l = arrayListOf<Any>()
+        val c = arrayListOf<Any>(1, "ok", 2)
+        l.add(c)
 
-                } else { // must fetch latest ptr from chain file
-                    Log.d("node", "fetching chunk hash from file ${fn}")
-                    val g = RandomAccessFile(fn, "rw")
-                    g.seek(g.length() - HASH_LEN)
-                    if (g.read(h) != h.size) {
-                        Log.d("node", "could not read() after seek")
-                        seq = -1;
-                    } else {
-                        var i = 0
-                        while (i < HASH_LEN)
-                            if (h[i].toInt() != 0)
-                                break;
-                            else
-                                i++
-                        if (i == HASH_LEN) // reached end of chain
-                            seq = -1;
-                    }
-                }
-                if (seq > 0) {
-                    val nextChunk = sz / TINYSSB_PKT_LEN;
-                    // FIXME: check if sidechain is already full, then swap '.' for '!' (e.g. after a crash)
-                    val lst = Bipf.mkList()
-                    val fidNr = context.tinyGoset.keys.indexOfFirst({
-                            k -> HelperFunctions.byteArrayCmp(k, fid) == 0
-                    })
-                    Bipf.list_append(lst, Bipf.mkInt(fidNr))
-                    Bipf.list_append(lst, Bipf.mkInt(seq))
-                    Bipf.list_append(lst, Bipf.mkInt(nextChunk))
-                    Bipf.list_append(chunkReqList, lst)
-                    val fct = { pkt: ByteArray,x: Int -> context.tinyNode.incoming_chunk(pkt,x) }
-                    v += (if (v.length == 0) "[ " else ", ") + "$fidNr.$seq.$nextChunk"
-                    // Log.d("node", "need chunk $fidNr.$seq.$nextChunk, armed for ${h.toHex()}, list now ${chunkReqList.cnt} (${lst.cnt})")
-                    context.tinyDemux.arm_blb(h, fct, fid, seq, nextChunk)
-                }
-            }
-        }
-        if (chunkReqList.cnt > 0) {
-            val buf = Bipf.encode(chunkReqList)
-            if (buf != null) {
-                context.tinyIO.enqueue(buf, context.tinyDemux.chnk_dmx)
-                Log.d("node", ">> sent CHUNK request ${v} ]")
-            }
-        }
+        val b = Bipf.bipf_loads(Bipf.encode(Bipf.mk(l))!!)!!
+
+        val lst = b.getBipfList()[0].getBipfList()
+
+        val first = lst[0].get()
+        val sec = lst[1].get()
+        val third = lst[2].get()
+
+        Log.d("Test", "$first, $sec, $third")
+
+
+        return*/
+        val want_buf = context.tinyRepo.mk_want_vect()
+        if (want_buf != null)
+            context.tinyIO.enqueue(want_buf, context.tinyDemux.want_dmx)
+
+        val chnk_buf = context.tinyRepo.mk_chnk_vect()
+        if (chnk_buf != null)
+            context.tinyIO.enqueue(chnk_buf, context.tinyDemux.chnk_dmx)
+
+        // TODO update_progress(vector.toSortedMap().values.toList(), "me")
     }
 
     fun incoming_pkt(buf: ByteArray, fid: ByteArray) {
-        Log.d("node", "incoming logEntry ${buf.size}B")
+        Log.d("node", "incoming logEntry ${buf.size}B, fid: ${fid.toHex()}")
         if (buf.size != TINYSSB_PKT_LEN) return
         context.tinyRepo.feed_append(fid, buf)
     }
 
-    fun incoming_chunk(buf: ByteArray, blbt_ndx: Int) {
-        Log.d("node", "incoming chunk ${buf.size}B, index=${blbt_ndx}")
+    fun incoming_chunk(buf: ByteArray, fid: ByteArray?, seq: Int) {
+        Log.d("node", "incoming chunk ${buf.size}B, fid=${fid?.toHex()}, seq=${seq}")
+        if (fid == null) return
         if (buf.size != TINYSSB_PKT_LEN) return
-        context.tinyRepo.sidechain_append(buf, blbt_ndx)
+        context.tinyRepo.sidechain_append(buf, fid, seq)
     }
 
-    fun publish_public_content(content: ByteArray): Boolean {
+    fun publish_public_content(content: ByteArray) {
         val repo = context.tinyRepo
         Log.d("node", "publish_public_content ${content.size}B")
-        val pkt = repo.mk_contentLogEntry(content)
-        Log.d("node", "publish_public_content --> pkt ${if (pkt == null) 0 else pkt.size}B")
-        Log.d("node", "publish_public_content --> content ${if (pkt == null) 0 else pkt.toHex()}B")
-        if (pkt == null) return false
-        return repo.feed_append(context.idStore.identity.verifyKey, pkt)
+        val pkt = repo.mk_logEntry(content)
+        //Log.d("node", "publish_public_content --> pkt ${if (pkt == null) 0 else pkt.size}B")
+        //Log.d("node", "publish_public_content --> content ${if (pkt == null) 0 else pkt.toHex()}B")
+        //if (pkt == null) return false
+        //return repo.feed_append(pkt, context.idStore.identity.verifyKey)
     }
 
     // all want vectors are sorted by the keys

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Node.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Node.kt
@@ -179,7 +179,7 @@ class Node(val context: MainActivity) {
     fun publish_public_content(content: ByteArray) {
         val repo = context.tinyRepo
         Log.d("node", "publish_public_content ${content.size}B")
-        val pkt = repo.mk_logEntry(content)
+        val seq = repo.mk_logEntry(content)
         //Log.d("node", "publish_public_content --> pkt ${if (pkt == null) 0 else pkt.size}B")
         //Log.d("node", "publish_public_content --> content ${if (pkt == null) 0 else pkt.toHex()}B")
         //if (pkt == null) return false

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Replica.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Replica.kt
@@ -185,6 +185,11 @@ class Replica(val context: MainActivity, val datapath: File, val fid: ByteArray)
         val fct = { buf: ByteArray, fid: ByteArray?, _: String? -> context.tinyNode.incoming_pkt(buf,fid!!) }
         context.tinyDemux.arm_dmx(new_dmx, fct, fid)
 
+        val (_, sz) = Bipf.varint_decode(pkt, DMX_LEN + 1, DMX_LEN + 4)
+        val content = pkt.sliceArray(8 + sz until 36)
+
+        context.wai.sendIncompleteEntryToFrontend(fid, seq, (nam + pkt).sha256().sliceArray(0 until HASH_LEN), content)
+
         if(sendToFront)
             context.wai.sendTinyEventToFrontend(fid, seq, (nam + pkt).sha256().sliceArray(0 until HASH_LEN), read_content(seq)!!)
         return true

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Replica.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Replica.kt
@@ -1,0 +1,451 @@
+package nz.scuttlebutt.tremolavossbol.tssb
+
+import android.util.AtomicFile
+import android.util.Log
+import nz.scuttlebutt.tremolavossbol.MainActivity
+import nz.scuttlebutt.tremolavossbol.crypto.SodiumAPI.Companion.sha256
+import nz.scuttlebutt.tremolavossbol.crypto.SodiumAPI.Companion.signDetached
+import nz.scuttlebutt.tremolavossbol.crypto.SodiumAPI.Companion.verifySignDetached
+import nz.scuttlebutt.tremolavossbol.utils.Bipf
+import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.DMX_LEN
+import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.DMX_PFX
+import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.HASH_LEN
+import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.PKTTYPE_chain20
+import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.PKTTYPE_plain48
+import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.TINYSSB_PKT_LEN
+import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toByteArray
+import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toHex
+import java.io.File
+import java.io.RandomAccessFile
+import kotlin.math.min
+
+class Pending(var cnr: Int, var rem: Int, var hptr: ByteArray, var pos: Int) {
+
+    fun toList(): ArrayList<Any> {
+       return arrayListOf(cnr, rem, hptr, pos)
+    }
+
+    companion object {
+        fun fromList(lst: ArrayList<Any>): Pending {
+            val cnr = lst[0] as Int
+            val rem = lst[1] as Int
+            val hptr = lst[2] as ByteArray
+            val pos = lst[3] as Int
+            return Pending(cnr, rem, hptr, pos)
+        }
+    }
+
+
+}
+
+class State {
+
+    var max_seq = 0
+    var max_pos = 0
+    var prev = ByteArray(20)
+    var pend_sc = mutableMapOf<Int, Pending>()
+
+    private fun toDict(): MutableMap<String, *> {
+        val dict = mutableMapOf<String, Any?>()
+        dict["max_seq"] = max_seq
+        dict["max_pos"] = max_pos
+        dict["prev"] = prev
+        val it = pend_sc.mapValues { it.value.toList() }
+        dict["pend_sc"] = pend_sc.mapValues { it.value.toList() }
+        return dict
+    }
+
+    fun toWire(): ByteArray {
+        val wire = toDict()
+        Log.d("to_wire", "wire_maxpos: ${Bipf.bipf_loads(Bipf.encode(Bipf.mkDict(toDict()))!!)!!.get()}")
+        return Bipf.encode(Bipf.mkDict(toDict()))!!
+    }
+
+    fun loadFromWire(wire: ByteArray) {
+        val dict = Bipf.bipf_loads(wire)?.getDict() as MutableMap<String, Any?>
+        max_seq = dict["max_seq"] as Int
+        max_pos = dict["max_pos"] as Int
+        prev = dict["prev"] as ByteArray
+        pend_sc = (dict["pend_sc"] as Map<Int, ArrayList<Any>>).mapValues { Pending.fromList(it.value) }.toMutableMap()
+    }
+}
+
+class Replica(val context: MainActivity, val datapath: File, val fid: ByteArray) {
+
+    private val path = File(datapath, fid.toHex())
+    private val log = File(path, "log.bin")
+    private val fnt = AtomicFile(File(path, "frontier.bin"))
+    private val mid = File(path, "mid.bin")
+
+    var state = State()
+
+    init {
+        path.mkdirs()
+        log.createNewFile()
+        mid.createNewFile()
+        if (fnt.baseFile.createNewFile()) {
+            persist_frontier(0, 0, fid.sliceArray(0 until 20))
+        }
+        state.loadFromWire(fnt.readFully())
+        Log.d("replica", "loaded prev: ${state.prev.toHex()} (fid: ${fid.toHex()}), length: ${log.length()}, max pos: ${state.max_pos}")
+        while (log.length() > state.max_pos) {
+            RandomAccessFile(log, "rwd").use { f ->
+                var pos = state.max_pos
+                Log.d("replica", "init pos: $pos")
+                f.seek(pos.toLong())
+                val pkt = ByteArray(TINYSSB_PKT_LEN)
+                f.read(pkt)
+                val seq = state.max_seq + 1
+                val nam = DMX_PFX + fid + seq.toByteArray() + state.prev
+                val dmx = context.tinyDemux.compute_dmx(nam)
+                if (!dmx.contentEquals(pkt.sliceArray(0 until DMX_LEN))) { // TODO isAuthor check (like in the simplepub implementation)
+                    f.setLength(pos.toLong())
+                    return@use
+                }
+
+                var chunk_cnt = 0
+                if (pkt[7].toInt() == PKTTYPE_chain20) {
+                    var (sz, len) = Bipf.varint_decode(pkt, DMX_LEN + 1, DMX_LEN + 4)
+                    len -= 48 - 20 - sz
+                    val ptr = pkt.sliceArray(36 until 56)
+                    chunk_cnt = (len + 99) / 100
+                    if (chunk_cnt > 0) {
+                        state.pend_sc[seq] = Pending(0, chunk_cnt, ptr, pos + TINYSSB_PKT_LEN)
+                    }
+
+                }
+                while (chunk_cnt > 0) {
+                    f.write(ByteArray(TINYSSB_PKT_LEN))
+                    chunk_cnt--
+                }
+                f.write(pos.toByteArray())
+                pos = f.filePointer.toInt()
+                persist_frontier(seq, pos, (nam + pkt).sha256().sliceArray(0 until HASH_LEN))
+            }
+        }
+    }
+
+    fun persist_frontier(seq: Int, pos: Int, prev: ByteArray) {
+        state.max_seq = seq
+        state.max_pos = pos
+        Log.d("persist_frontier", "pos: $pos")
+        state.prev = prev
+        val f = fnt.startWrite()
+        f.write(state.toWire())
+        fnt.finishWrite(f)
+    }
+
+    fun ingest_entry_pkt(pkt: ByteArray, seq: Int): Boolean {
+        Log.d("Replica", "ingest_entry_pkt")
+        var sendToFront = false
+        if (pkt.size != TINYSSB_PKT_LEN) return false
+        if (seq != state.max_seq + 1) {
+            Log.d("Replica", "ingest_entry: wrong seq nr")
+            return false
+        }
+        val nam = DMX_PFX + fid + seq.toByteArray() + state.prev
+        val dmx = context.tinyDemux.compute_dmx(nam)
+        if (!dmx.contentEquals(pkt.sliceArray(0 until DMX_LEN))) {
+            Log.d("Replica", "ingest_entry: dmx mismatch")
+            return false
+        }
+        // TODO
+        if (!verifySignDetached(
+                pkt.sliceArray(56..pkt.lastIndex),
+                nam + pkt.sliceArray(0 until 56),
+                fid
+            )
+        ) {
+            Log.d("Replica", "ingest_entry: signature verify failed")
+            return false
+        }
+        Log.d("Replica", "DEBUG REP")
+        var chunk_cnt = 0
+        if (pkt[7].toInt() == PKTTYPE_chain20) {
+            var (len, sz) = Bipf.varint_decode(pkt, DMX_LEN + 1, DMX_LEN + 4)
+            len -= 48 - 20 - sz
+            chunk_cnt = (len + 99) / 100
+        }
+        Log.d("Replica", "DEBUG REP 2")
+        var log_entry = pkt + ByteArray(chunk_cnt * TINYSSB_PKT_LEN)
+        log_entry += state.max_pos.toByteArray()
+        log.appendBytes(log_entry)
+        Log.d("Replica", "DEBUG REP 3, chunk_cnt: $chunk_cnt")
+        if (chunk_cnt > 0) {
+            val ptr = pkt.sliceArray(36 until 56)
+            state.pend_sc[seq] = Pending(0, chunk_cnt, ptr, state.max_pos + TINYSSB_PKT_LEN)
+            val chunk_fct = { chunk: ByteArray, fid: ByteArray?, seq: Int -> context.tinyNode.incoming_chunk(chunk,fid,seq) }
+            context.tinyDemux.arm_blb(ptr, chunk_fct, fid, seq, 0)
+        } else { // no sidechain, entry is complete
+            sendToFront = true
+        }
+
+        mid.appendBytes((nam + pkt).sha256().sliceArray(0 until HASH_LEN))
+        val pos = state.max_pos + log_entry.size
+        persist_frontier(seq, pos, (nam + pkt).sha256().sliceArray(0 until HASH_LEN))
+
+        context.tinyDemux.arm_dmx(dmx) // remove old dmx handler
+        // arm dmx handler for next entry
+        val new_nam = DMX_PFX + fid + (seq + 1).toByteArray() + (nam + pkt).sha256().sliceArray(0 until HASH_LEN)
+        val new_dmx = context.tinyDemux.compute_dmx(new_nam)
+        val fct = { buf: ByteArray, fid: ByteArray?, _: String? -> context.tinyNode.incoming_pkt(buf,fid!!) }
+        context.tinyDemux.arm_dmx(new_dmx, fct, fid)
+
+        if(sendToFront)
+            context.wai.sendTinyEventToFrontend(fid, seq, (nam + pkt).sha256().sliceArray(0 until HASH_LEN), read(seq)!!)
+        return true
+    }
+
+    fun ingest_chunk_pkt(pkt: ByteArray, seq: Int): Boolean {
+        Log.d("replica", "ingest_chunk-pkt")
+        if (pkt.size != TINYSSB_PKT_LEN) return false
+        val pend: Pending
+        var pos: Int
+        try {
+            pend = state.pend_sc[seq]!!
+            assert(pend.hptr.contentEquals(pkt.sha256().sliceArray(0 until HASH_LEN)))
+            RandomAccessFile(log, "rwd").use { f ->
+                f.seek(pend.pos.toLong())
+                f.write(pkt)
+                pos = f.filePointer.toInt()
+            }
+            context.tinyDemux.arm_blb(pend.hptr) // remove old chnk handler
+        } catch (e: Exception) {
+            return false
+        }
+        if (pend.rem <= 1) { //sidechain is complete
+            state.pend_sc.remove(seq)
+            val content = read(seq)
+            val message_id = get_mid(seq)
+            Log.d("ingest_chnk", "sidechain complete, content: ${content?.toHex()}, mid: ${message_id?.toHex()}")
+            if (message_id != null && content != null) {
+                context.wai.sendTinyEventToFrontend(fid, seq, message_id, content)
+            }
+        } else {
+            pend.cnr++
+            pend.rem--
+            pend.hptr = pkt.sliceArray(pkt.size - 20..pkt.lastIndex)
+            pend.pos = pos
+            Log.d("ingest_chnk", "arm new chnk dmx, cnr: ${pend.cnr}, rem: ${pend.rem}")
+            val chunk_fct = { chunk: ByteArray, fid: ByteArray?, seq: Int -> context.tinyNode.incoming_chunk(chunk,fid,seq) }
+            context.tinyDemux.arm_blb(pend.hptr, chunk_fct, fid, seq, pend.cnr)
+        }
+        val f = fnt.startWrite()
+        f.write(state.toWire())
+        fnt.finishWrite(f)
+
+
+        return true
+    }
+
+    fun get_mid(seq: Int): ByteArray? {
+        Log.d("get_mid", "for seq: $seq")
+        if(seq < 1 || seq > state.max_seq)
+            return null
+        val pos = (seq - 1) * HASH_LEN
+        if (pos >= mid.length())
+            return null
+        val buf = ByteArray(HASH_LEN)
+
+        RandomAccessFile(mid, "r").use {f ->
+            f.seek(pos.toLong())
+            f.read(buf)
+        }
+        return buf
+
+    }
+
+    fun get_next_seq(): Pair<Int, ByteArray> {
+        val seq = state.max_seq + 1
+        val nam = DMX_PFX + fid + seq.toByteArray() + state.prev
+        return Pair(seq, nam.sha256().sliceArray(0 until DMX_LEN))
+    }
+
+    fun get_open_chains(cursor: Int = 0): MutableMap<Int, Pending> { // FIXME: Unused Parameter cursor
+        return state.pend_sc
+    }
+
+    fun get_entry_pkt(seq: Int): ByteArray? {
+        try {
+            Log.d("get_entry", "seq: $seq, max: ${state.max_seq}")
+            if(seq < 1 || seq > state.max_seq)
+                return null
+            var pos = log.length()
+            var cnt = state.max_seq - seq + 1
+            RandomAccessFile(log, "rwd").use { f ->
+                while (cnt > 0) {
+                    f.seek(pos - 4)
+                    pos = f.readInt().toLong()
+                    cnt--
+                }
+                f.seek(pos)
+                val buf = ByteArray(TINYSSB_PKT_LEN)
+                f.read(buf)
+                return buf
+            }
+
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    fun get_content_len(seq: Int): Pair<Int, Int>? {
+        val pkt = get_entry_pkt(seq)
+        if (pkt == null)
+            return null
+        if (pkt[7].toInt() == PKTTYPE_plain48)
+            return Pair(48, 48)
+        if (pkt[7].toInt() == PKTTYPE_chain20) {
+            val (len, sz) = Bipf.varint_decode(pkt, DMX_LEN + 1, DMX_LEN + 4)
+            if (!state.pend_sc.containsKey(seq))
+                return Pair(len, len)
+            val available = (48 - 20 - sz) + 100 * state.pend_sc[seq]!!.cnr
+            return Pair(available, len)
+        }
+        return null
+    }
+
+    fun get_chunk_pkt(seq: Int, cnr: Int): ByteArray? {
+        try {
+            assert(seq >= 1 && seq <= state.max_seq)
+            if (state.pend_sc.containsKey(seq)) {
+                if (cnr >= state.pend_sc[seq]!!.cnr)
+                    return null
+            }
+            var pos = log.length()
+            var cnt = state.max_seq - seq + 1
+            var lim = pos
+            RandomAccessFile(log, "rwd").use { f ->
+                while (cnt > 0) {
+                    f.seek(pos - 4)
+                    lim = pos
+                    pos = f.readInt().toLong()
+                    cnt--
+                }
+                pos += TINYSSB_PKT_LEN * (cnr + 1)
+                if (pos > lim - 120)
+                    return null
+                f.seek(pos)
+                val buf = ByteArray(TINYSSB_PKT_LEN)
+                f.read(buf)
+                return buf
+            }
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    fun read(seq: Int): ByteArray? {
+        Log.d("read", "DEBUG, max seq: ${state.max_seq}, seq: $seq")
+        if (state.max_seq < seq || seq < 1)
+            return null
+        Log.d("read", "DEBUG1.1")
+        var pos = log.length()
+        Log.d("read", "DEBUG1.2, pos: $pos")
+        var cnt = state.max_seq - seq + 1
+        RandomAccessFile(log, "rwd").use { f ->
+            while (cnt > 0) {
+                f.seek(pos - 4)
+                pos = f.readInt().toLong()
+                cnt--
+            }
+            Log.d("read", "DEBUG2")
+            f.seek(pos)
+            val pkt = ByteArray(TINYSSB_PKT_LEN)
+            f.read(pkt)
+            Log.d("read", "DEBUG3")
+            if (pkt[7].toInt() == PKTTYPE_plain48)
+                return pkt.sliceArray(8 until 56)
+            if (pkt[7].toInt() == PKTTYPE_chain20) { //read whole sidechain
+                Log.d("read", "DEBUG4")
+                val (chain_len, sz) = Bipf.varint_decode(pkt, DMX_LEN + 1, DMX_LEN + 4)
+                var content = pkt.sliceArray(8 + sz until 36)
+                var blocks = (chain_len - content.size + 99) / 100
+                while (blocks > 0) {
+                    f.read(pkt)
+                    content += pkt.sliceArray(0 until 100)
+                    blocks--
+                }
+                return content
+            }
+            return null // unknown pkt type
+
+        }
+    }
+
+
+    // TODO implement PKTTYPE_plain48
+    fun write48(c: ByteArray): Int {
+        var content = c
+        assert(log.length().toInt() == state.max_pos)
+        if (content.size < 48) {
+            content += ByteArray(48-content.size) //TODO: Is this correct? (compare to simplepub code l. 237)
+        } else {
+            content = content.sliceArray(0 until 48)
+        }
+        val seq = state.max_seq + 1
+        val nam = DMX_PFX + fid + seq.toByteArray() + state.prev
+        val dmx = context.tinyDemux.compute_dmx(nam)
+        val msg = dmx + ByteArray(1) { PKTTYPE_plain48.toByte()} + content
+        val wire = msg + signDetached(nam + msg, context.idStore.identity.signingKey!!)
+        assert(wire.size == TINYSSB_PKT_LEN)
+        assert(verifySignDetached(
+            wire.sliceArray(56..wire.lastIndex),
+            nam + wire.sliceArray(0 until 56),
+            fid
+        ))
+        log.appendBytes(wire + state.max_pos.toByteArray())
+        persist_frontier(seq, wire.size + 4, (nam +wire).sha256().sliceArray(0 until HASH_LEN))
+        return seq
+    }
+
+    fun write(c: ByteArray): Int {
+        var content = c
+        assert(log.length().toInt() == state.max_pos) // TODO assert can throw an Error which is not handled
+        val chunks = ArrayList<ByteArray>()
+        val seq = state.max_seq + 1
+        val sz = Bipf.varint_encode(content.size)
+        var payload = sz + content.sliceArray(0 until min(28 - sz.size, content.size - 1))
+        if (payload.size < 28) { //TODO: compare with simplepub code l. 260
+            payload += ByteArray(28 - payload.size)
+        }
+        content = content.sliceArray(28 - sz.size .. content.lastIndex)
+        var i = content.size % 100
+        if (i > 0)
+            content += ByteArray(100-i)
+        var ptr = ByteArray(HASH_LEN)
+        while (content.size > 0) {
+            val buf = content.sliceArray(content.size - 100 .. content.lastIndex) + ptr
+            chunks.add(buf)
+            ptr = buf.sha256().sliceArray(0 until HASH_LEN)
+            content = content.sliceArray(0 .. content.lastIndex - 100)
+        }
+        chunks.reverse()
+        payload += ptr
+        val nam = DMX_PFX + fid + seq.toByteArray() + state.prev
+        val dmx = context.tinyDemux.compute_dmx(nam)
+
+        Log.d("replica write", "dmx is ${dmx.toHex()}, chnk_cnt: ${chunks.size}")
+        val msg = dmx + ByteArray(1) { PKTTYPE_chain20.toByte()} + payload
+        var wire = msg + signDetached(nam + msg, context.idStore.identity.signingKey!!)
+        assert(wire.size == TINYSSB_PKT_LEN)
+        assert(verifySignDetached(
+            wire.sliceArray(56..wire.lastIndex),
+            nam + wire.sliceArray(0 until 56),
+            fid
+        ))
+        chunks.add(0, wire)
+        var log_entry = chunks.reduce {acc, it -> acc + it}
+        log_entry += state.max_pos.toByteArray()
+        Log.d("size", "size before: ${log.length()}")
+        log.appendBytes(log_entry)
+        // save mid
+        mid.appendBytes((nam + wire).sha256().sliceArray(0 until HASH_LEN))
+        //Log.d("sizes", "sizes: dmx: ${dmx.size}, +1, payload: ${payload.size}, sign: ${signDetached(nam + msg, context.idStore.identity.signingKey!!).size}")
+        persist_frontier(seq, state.max_pos + log_entry.size, (nam + wire).sha256().sliceArray(0 until HASH_LEN))
+        Log.d("write", "new max pos: ${state.max_pos}")
+        context.wai.sendTinyEventToFrontend(fid, seq, (nam + wire).sha256().sliceArray(0 until HASH_LEN), c)
+        Log.d("replica", "write success, len: ${log_entry.size}")
+        return seq
+    }
+}

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Replica.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Replica.kt
@@ -451,4 +451,9 @@ class Replica(val context: MainActivity, val datapath: File, val fid: ByteArray)
         Log.d("replica", "write success, len: ${log_entry.size}")
         return seq
     }
+
+    fun isSidechainComplete(seq: Int): Boolean {
+        return !state.pend_sc.containsKey(seq)
+    }
+
 }

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
@@ -129,7 +129,7 @@ class Repo(val context: MainActivity) {
     }
 
     fun mk_want_vect(): ByteArray? {
-        want_is_valid = false // not implemented yet
+        want_is_valid = false // TODO optimization not implemented yet
         if (want_is_valid) return null
 
         val lst = ArrayList<Int>()
@@ -154,9 +154,19 @@ class Repo(val context: MainActivity) {
             if (encoding_len > 100)
                 break
         }
+
         want_offs = (want_offs + i + 1) % context.tinyGoset.keys.size
         want_is_valid = true
+
+
         if(lst.size > 1) {
+            var vec = lst.slice(1 .. lst.lastIndex) // want_vector without offset
+            vec = vec.mapIndexed { index, i ->
+                val new_idx =(index + want_offs) % vec.size
+                lst.slice(1 .. lst.lastIndex)[new_idx]}
+
+            context.tinyNode.update_progress(vec, "me")
+
             return Bipf.encode(Bipf.mkList(lst))
         }
         return null

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
@@ -1,8 +1,6 @@
 package nz.scuttlebutt.tremolavossbol.tssb
 
-import android.content.Context
 import android.content.Context.MODE_PRIVATE
-import android.util.Log
 import nz.scuttlebutt.tremolavossbol.MainActivity
 import nz.scuttlebutt.tremolavossbol.crypto.SodiumAPI.Companion.sha256
 import nz.scuttlebutt.tremolavossbol.utils.Bipf
@@ -14,12 +12,10 @@ import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.decodeHex
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toBase64
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toByteArray
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toHex
-import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toInt32
 import java.io.File
 import java.io.RandomAccessFile
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import kotlin.math.log
 import kotlin.random.Random
 
 class Repo(val context: MainActivity) {
@@ -222,7 +218,7 @@ class Repo(val context: MainActivity) {
     }
 
     fun feed_read_content(fid: ByteArray, seq: Int): ByteArray? {
-        return fid2replica(fid)?.read(seq)
+        return fid2replica(fid)?.read_content(seq)
     }
 
     /**

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
@@ -303,6 +303,7 @@ class Repo(val context: MainActivity) {
                 frontier.delete()
             frontier.createNewFile()
             frontier.appendBytes(new_state.toWire())
+            context.wai.frontend_frontier.edit().putInt(f.name, new_state.max_pos + 1).apply()
 
             Files.move(new_log.toPath(), File(feed_dir, "log.bin").toPath(), StandardCopyOption.ATOMIC_MOVE)
             File(feed_dir, "log").delete()

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
@@ -3,431 +3,203 @@ package nz.scuttlebutt.tremolavossbol.tssb
 import android.content.Context.MODE_PRIVATE
 import android.util.Log
 import nz.scuttlebutt.tremolavossbol.MainActivity
-import nz.scuttlebutt.tremolavossbol.crypto.SodiumAPI.Companion.sha256
-import nz.scuttlebutt.tremolavossbol.crypto.SodiumAPI.Companion.signDetached
-import nz.scuttlebutt.tremolavossbol.crypto.SodiumAPI.Companion.verifySignDetached
-import nz.scuttlebutt.tremolavossbol.utils.Bipf.Companion.varint_decode
-import nz.scuttlebutt.tremolavossbol.utils.Bipf.Companion.varint_encode
-import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.DMX_LEN
+import nz.scuttlebutt.tremolavossbol.utils.Bipf
 import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.DMX_PFX
 import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.FID_LEN
-import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.HASH_LEN
-import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.PKTTYPE_chain20
-import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.PKTTYPE_plain48
-import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.TINYSSB_DIR
-import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.TINYSSB_PKT_LEN
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.decodeHex
-import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toBase64
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toByteArray
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toHex
 import java.io.File
-import java.io.RandomAccessFile
-
-class Feed(fid: ByteArray) {
-    val fid = fid
-    // var seq = 0
-    var next_seq = 1
-    var prev_hash = fid.sliceArray(0..HASH_LEN-1)
-    var max_prev_seq = 0
-}
-
-// tremola: [fid,mid,xrf,app,dat]
-// raw       32B,20B,20B,2B,X
-// enc       64B,40B,40B,2B,X
-// msg       body=BIPF(XRF~20B,APP~2B,??~DAT)
-class LogTinyEntry(fid: ByteArray, seq: Int, mid: ByteArray, body: ByteArray) {
-    val fid = fid // author
-    val seq = seq
-    val mid = mid // msg hash
-    val body = body // Bipf(APP,XRF,OTHERDATA)
-}
+import kotlin.random.Random
 
 class Repo(val context: MainActivity) {
+    val TINYSSB_DIR = "tinyssb"
     val FEED_DIR = "feeds"
-    val feeds = ArrayList<Feed>()
+    private val replicas = ArrayList<Replica>()
+    private var want_is_valid = false
+    private var chnk_is_valid = false
+    private var want_offs = 0
+    private var chnk_offs = 0
 
-    fun _feed_index(fid: ByteArray): Int {
-        var i = 0
-        for (f in feeds) {
-            if (f.fid.contentEquals(fid)) return i
-            i++
-        }
-        return -1
-    }
-
-    fun fid2rec(fid: ByteArray, createIfNeeded: Boolean =false): Feed? {
-        for (f in feeds)
-            if (f.fid.contentEquals(fid)) {
-                // Log.d("repo", "use feed record ${f} next_seq=${f.next_seq}")
-                return f
-            }
-        if (!createIfNeeded)
-            return null
-        // Log.d("repo", "create new feed ${fid.toHex()}")
-        val frec = Feed(fid)
-        feeds.add(frec)
-        // Log.d("repo", "use NEW feed record ${frec}")
-        return frec
-    }
-
-    fun _openFile(fid: ByteArray, mode: String, seq: Int = -1, blob: Int = -1): RandomAccessFile {
-        // blob=-1: create filename for MID hash, blob=1: incomplete sidechain, blob=0: full sidechain
-        val feeds_dir = File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR)
-        val fdir = File(feeds_dir, fid.toHex())
-        fdir.mkdirs()
-        var fn: String
-        if (blob == -1) {
-            if (seq >= 0)
-                fn = "mid"
-            else
-                fn = "log"
-        } else if (blob > 0)
-            fn = "!" + seq.toString()
-        else
-            fn = "-" + seq.toString()
-        val f = File(fdir, fn)
-        if (!f.exists()) {
-            f.createNewFile()
-            if (fn == "log")
-                File(fdir, "mid").createNewFile()
-        }
-        return RandomAccessFile(f, mode)
-    }
-
-    fun delete_feed(fid: ByteArray) {
-        val feeds_dir = File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR)
-        val feed = File(feeds_dir, fid.toHex())
-        if (feed.exists() && feed.isDirectory)
-            for (f in feed.listFiles())
-                f.deleteRecursively()
-        val rec = fid2rec(fid)
-        rec?.next_seq = 1
-        rec?.prev_hash = fid.sliceArray(0 until HASH_LEN)
-    }
-
-    fun repo_clean(dir: File) {
-        for (f in dir.listFiles()) {
+    private fun clean(dir: File) {
+        for (f in dir.listFiles() ?: emptyArray()) {
             if (f.isDirectory)
-                repo_clean(File(dir, f.name))
+                clean(File(dir, f.name))
             f.delete()
         }
     }
 
-    fun repo_reset() {
-        repo_clean(context.getDir(TINYSSB_DIR, MODE_PRIVATE));
+    fun delete_feed(fid: ByteArray) {
+        clean(File(File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR), fid.toHex()))
     }
 
-    fun repo_load() {
+    fun reset() {
+        val fdir = File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR)
+        clean(fdir);
+    }
+
+    fun load() {
         val fdir = File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR)
         fdir.mkdirs()
-        for (f in fdir.listFiles()) {
-            if (!f.isDirectory || f.name.length != 2* FID_LEN) continue
-            val fid = f.name.decodeHex()
-            var ndx = _feed_index(fid)
-            if (ndx < 0) {
-                ndx = feeds.size
-                feeds.add(Feed(fid))
-            }
-            val frec = feeds[ndx] // feed record
-            frec.next_seq = feed_len(fid) + 1
-            for (g in f.listFiles()) { // move away from old style filename
-                // (files starting with dot cannot be selected for uploading)
-                if (g.name[0] == '.')
-                    g.renameTo(File(f,"-" + g.name.substring(1..g.name.lastIndex)))
-            }
-            val m = File(f,"mid")
-            if (!m.exists())
-                m.createNewFile()
-            if (m.length() == 0L && frec.next_seq != 1)
-                Log.d("repo", "FIXME: must repair messageID file!")
-            else if (m.length() >= HASH_LEN) {
-                val raf = RandomAccessFile(m, "r")
-                raf.seek(raf.length() - HASH_LEN)
-                raf.read(frec.prev_hash)
-            }
-        }
-        // FIXME: check next_seq for each feed, whether the log file (no suffix) has more log entries
-        // and therefore we need to compute a new message id, create a new file with a seq nr suffix
-        // ... while ((feeds[ndx].max_prev_seq+1) < feeds[ndx].next_seq) .. compute missing prev values, cycle files
 
-        for (f in feeds) {
-            Log.d("repo", "loaded feed ${f.fid.toHex()}")
-            context.tinyGoset._include_key(f.fid)
+        for (f in fdir.listFiles { file -> file.isDirectory && file.name.length == 2 * FID_LEN} ?: emptyArray()) {
+            add_replica(f.name.decodeHex())
         }
-        context.tinyGoset.adjust_state()
+
     }
 
-    fun new_feed(fid: ByteArray) {
-        Log.d("repo", "create empty log")
-        val fdir = File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR)
-        val ldir = File(fdir, fid.toHex())
-        ldir.mkdirs()
-        try {
-            repo_clean(ldir)
-        } catch (e: Exception) {}
-        // context.getDir(p, MODE_PRIVATE) // creates this dir if necessary
-        File(ldir, "log").createNewFile() // create empty log file
-        File(ldir, "mid").createNewFile() // create empty log file
-        feeds.add(Feed(fid))
-        if(context.isWaiInitialized())
-            context.wai.eval("b2f_new_contact(\"@${fid.toBase64()}.ed25519\")") // notify frontend
+    fun add_replica(fid: ByteArray) {
+        if (replicas.any { it.fid.contentEquals(fid) })
+            return
+        val new_r = Replica(context, File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR), fid)
+        replicas.add(new_r)
+        val seq = new_r.state.max_seq + 1
+        val nam = DMX_PFX + fid + seq.toByteArray() + new_r.state.prev
+        val dmx = context.tinyDemux.compute_dmx(nam)
+        val fct = { buf: ByteArray, fid: ByteArray?, _: String? -> context.tinyNode.incoming_pkt(buf,fid!!) }
+        context.tinyDemux.arm_dmx(dmx, fct, fid)
+
+        val chains = new_r.get_open_chains()
+        val chunk_fct = { chunk: ByteArray, fid: ByteArray?, seq: Int -> context.tinyNode.incoming_chunk(chunk,fid,seq) }
+        for ((seq, p) in chains) {
+            context.tinyDemux.arm_blb(p.hptr, chunk_fct,fid,seq, p.cnr)
+        }
+
+        if (context.tinyGoset.keys.size > 1) {
+            want_offs = Random.nextInt(0, context.tinyGoset.keys.size - 1)
+            chnk_offs = Random.nextInt(0, context.tinyGoset.keys.size - 1)
+        }
+
+        want_is_valid = false
+        chnk_is_valid = false
+
     }
 
-    fun feed_read_mid(fid: ByteArray, seq: Int): ByteArray? {
-        if (seq < 1) return null
-        val fdir = File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR)
-        val f = RandomAccessFile(File(File(fdir, fid.toHex()), "mid"), "r")
-        if (f.length()/HASH_LEN < seq) return null
-        f.seek((HASH_LEN * (seq-1)).toLong())
-        val buf = ByteArray(HASH_LEN)
-        val sz = f.read(buf, 0, buf.size)
-        f.close()
-        return if (sz == buf.size) buf else null
+    fun fid2replica(fid: ByteArray): Replica? {
+        return replicas.find { it.fid.contentEquals(fid) }
     }
 
     fun feed_read_pkt(fid: ByteArray, seq: Int): ByteArray? {
-        if (seq < 1) return null
-        val f = _openFile(fid, "r", -1)
-        // Log.d("repo", "read_pkt: file length ${f.length()}")
-        if (f.length()/TINYSSB_PKT_LEN < seq) {
-            f.close()
+        val r = fid2replica(fid)
+        if (r == null)
             return null
-        }
-        f.seek((TINYSSB_PKT_LEN * (seq-1)).toLong())
-        val buf = ByteArray(TINYSSB_PKT_LEN)
-        val sz = f.read(buf, 0, buf.size)
-        f.close()
-        if (sz != buf.size)
-            Log.d("repo","could not read packet #${seq}")
-        return if (sz == buf.size) buf else null
+        return r.get_entry_pkt(seq)
     }
 
     fun feed_read_chunk(fid: ByteArray, seq: Int, cnr: Int): ByteArray? {
-        var f: RandomAccessFile? = null
-        try {
-            f = _openFile(fid, "r", seq, 0)
-        } catch (e: Exception) {
-            try {
-                f = _openFile(fid, "r", seq, 1)
-            } catch (e: Exception) {}
-        }
-        if (f == null) return null
-        f.seek((TINYSSB_PKT_LEN * cnr).toLong())
-        val buf = ByteArray(TINYSSB_PKT_LEN)
-        val sz = f.read(buf, 0, buf.size)
-        f.close()
-        return if (sz == buf.size) buf else null
-    }
-
-    fun feed_read_content(fid: ByteArray, seq: Int): Pair<ByteArray?,ByteArray?> {
-        val logEntry = feed_read_pkt(fid, seq)
-        if (logEntry == null) return null to null
-        val mid = feed_read_mid(fid, seq)
-        if (mid == null) return null to null
-        if (logEntry[DMX_LEN].toInt() == PKTTYPE_plain48)
-            return logEntry.sliceArray(DMX_LEN+1..DMX_LEN+1+48-1) to mid
-        if (logEntry[DMX_LEN].toInt() != PKTTYPE_chain20) return null to null
-        val (sz, len) = varint_decode(logEntry, DMX_LEN+1, DMX_LEN+4)
-        if (sz <= (28-len))
-            return logEntry.sliceArray(DMX_LEN+1+len..DMX_LEN+1+len+sz-1) to mid
-        var content = logEntry.sliceArray(DMX_LEN+1+len..DMX_LEN+1+28-1)
-        val sidechain = _openFile(fid, "r", seq, 0)
-        while (true) {
-            val buf = ByteArray(TINYSSB_PKT_LEN)
-            if (sidechain.read(buf) != TINYSSB_PKT_LEN)
-                break
-            content += buf.sliceArray(0..TINYSSB_PKT_LEN - HASH_LEN - 1)
-        }
-        sidechain.close()
-        if (content.size < sz)
-            return null to null
-        if (content.size == sz)
-            return content to mid
-        Log.d("repo", "recovered sidechain content is ${content.sliceArray(0..sz-1).toHex()}")
-        return content.sliceArray(0..sz-1) to mid
-    }
-
-    fun feed_len(fid: ByteArray): Int {
-        val fdir = File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR)
-        val f = File(File(fdir, fid.toHex()), "log")
-        val cnt = f.length().toInt()/TINYSSB_PKT_LEN
-        return cnt
-    }
-
-    fun mk_contentLogEntry(content: ByteArray): ByteArray? {
-        val fid = context.idStore.identity.verifyKey
-        val frec = fid2rec(fid, false)
-        if (frec == null) {
-            Log.d("node","unknown fid")
+        val r = fid2replica(fid)
+        if (r == null)
             return null
-        }
-        Log.d("repo", "creating content of length ${content.size} ${content.toHex()}")
-        val sz_enc = varint_encode(content.size)
-        val intro: ByteArray
-        var ptr: ByteArray
-        Log.d("repo", "varint size: ${sz_enc.size}")
-        if (sz_enc.size + content.size <= 28) {
-            intro = sz_enc + content + ByteArray(28 - sz_enc.size - content.size)
-            ptr = ByteArray(HASH_LEN)
-        } else {
-            val i = 28 - sz_enc.size
-            intro = sz_enc + content.sliceArray(0..i-1)
-            var remaining: ByteArray? = content.sliceArray(i..content.lastIndex)
-            val chunks = ArrayList<ByteArray>(0)
-            ptr = ByteArray(HASH_LEN)
-            while (remaining != null) {
-                var len = remaining.size % 100
-                if (len == 0) len = 100
-                var pkt = remaining.sliceArray(remaining.size - len..remaining.lastIndex)
-                pkt += ByteArray(100 - len) + ptr
-                chunks.add(pkt)
-                ptr = pkt.sha256().sliceArray(0..HASH_LEN - 1)
-                if (len >= remaining.size)
-                    remaining = null
-                else
-                    remaining = remaining.sliceArray(0..remaining.lastIndex - len)
-            }
-            Log.d("repo", "number of chunks= ${chunks.size}")
-            if (chunks.size > 0) {
-                val chain = _openFile(fid, "rw", frec.next_seq, 0)
-                for (b in chunks.reversed())
-                    chain.write(b)
-                chain.close()
-            }
-        }
-        Log.d("repo", "mkLogEntry |intro|=${intro.size} |ptr|=${ptr.size}")
-        Log.d("repo", "mkLogEnty intro=${intro.toHex()}" )
-        val nm0 = fid + frec.next_seq.toByteArray() + frec.prev_hash
-        val dmx = context.tinyDemux.compute_dmx(nm0)
-        val msg = dmx + ByteArray(1) {PKTTYPE_chain20.toByte()} + intro + ptr
-        val me = context.idStore.identity
-        // don't append here (although we presisted the chunks)
-        return msg + signDetached(DMX_PFX + nm0 + msg, me.signingKey!!)
+        return r.get_chunk_pkt(seq, cnr)
     }
 
-    fun feed_append(fid: ByteArray, pkt: ByteArray): Boolean {
-        var ndx = _feed_index(fid)
-        if (ndx < 0) {
-            Log.d("repo", "no such feed ${fid.toHex()}")
+    fun feed_append(fid: ByteArray, buf: ByteArray): Boolean {
+        val r = fid2replica(fid)
+        if (r == null) {
             return false
         }
-        // check dmx
-        val seq = feeds[ndx].next_seq
-        Log.d("repo", "append seq=${seq}, pkt= ${pkt.toHex()}")
-        val nm0 = fid + seq.toByteArray() + feeds[ndx].prev_hash
-        val dmx = context.tinyDemux.compute_dmx(nm0)
-        if (!pkt.sliceArray(0..DMX_LEN-1).contentEquals(dmx)) { // wrong dmx field
-            Log.d("repo", " DMX mismatch")
-            return false
-        }
-        // check signature
-        val buf = DMX_PFX + nm0 + pkt
-        // pkt + 56, buf, strlen(DMX_PFX) + FID_LEN + 4 + HASH_LEN + 56, fid);
-        if (!verifySignDetached(pkt.sliceArray(56..pkt.lastIndex),
-                buf.sliceArray(0..buf.lastIndex-64), fid)) {
-            Log.d("repo", "ed25519 signature verification failed")
-            return false
-        }
-        Log.d("repo", "  writing pkt to log (seq=${seq})")
-        var f = _openFile(fid, "rw")
-        f.seek(f.length())
-        f.write(pkt)
-        f.close()
-        // prev hash data
-        val h = buf.sha256().sliceArray(0..HASH_LEN-1)
-        feeds[ndx].prev_hash = h
-        if (feeds[ndx].next_seq >= 1) { // should always be the case
-            f = _openFile(fid, "rw", 1) //
-            f.seek(f.length())
-            f.write(h)
-            f.close()
-        }
-        val d = File(File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR),fid.toHex())
-        if (feeds[ndx].next_seq >= 2) { // above replaces old MID file
-            File(d, "+" + (feeds[ndx].next_seq - 1).toString()).delete()
-        }
-        //xx
-        feeds[ndx].next_seq++
-        Log.d("repo", "append next_seq now ${feeds[ndx].next_seq}")
 
-
-        if (pkt[DMX_LEN].toInt() == PKTTYPE_plain48) {
-            Log.d("repo", "plain 48")
-            val e = LogTinyEntry(fid, seq, h, pkt.sliceArray(DMX_LEN + 1..DMX_LEN + 1 + 48 - 1))
-            context.wai.sendTinyEventToFrontend(e)
-        }
-        if (pkt[DMX_LEN].toInt() == PKTTYPE_chain20) {
-            val (sz, len) = varint_decode(pkt, DMX_LEN + 1, DMX_LEN + 4)
-            // Log.d("repo", "load sidechain of length ${sz}B")
-            Log.d("repo", "sz: ${sz}")
-            Log.d("repo", "len: ${len}")
-            if (sz <= 28 - len) {
-                val content = pkt.sliceArray(DMX_LEN + 1 + len..DMX_LEN + 1 + len + sz - 1)
-                val e = LogTinyEntry(fid, seq, h, content)
-                Log.d("repo", "Logentry content:${content.toHex()} ")
-                context.wai.sendTinyEventToFrontend(e)
-                // File(d,"-"+seq.toString()).createNewFile()
-            } else {
-                if (File(d, "-" + seq.toString()).exists()) {
-                    val (content,mid) = feed_read_content(fid, seq)
-                    if (content != null) {
-                        Log.d("repo", "Logentry content > 48:${content} ")
-                        val e = LogTinyEntry(fid, seq, mid!!, content)
-                        context.wai.sendTinyEventToFrontend(e)
-                    }
-                } else {
-                    File(d, "!" + seq.toString()).createNewFile()
-                    Log.d("repo", "Logentry wait for sidechain ")
-                    // and wait until the sidechain has been loaded to announce it to the frontend
-                }
-            }
-        }
-
-        context.tinyDemux.arm_dmx(pkt.sliceArray(0..DMX_LEN-1)); // remove old DMX handler
-        // install handler for next pkt:
-        val new_dmx = context.tinyDemux.compute_dmx(fid + feeds[ndx].next_seq.toByteArray()
-                                                    + feeds[ndx].prev_hash)
-        val fct = { buf: ByteArray, fid: ByteArray?, _: String? -> context.tinyNode.incoming_pkt(buf,fid!!) }
-        context.tinyDemux.arm_dmx(new_dmx, fct, fid)
-
-        return true
+        val success = r.ingest_entry_pkt(buf, r.state.max_seq + 1)
+        if (success)
+            want_is_valid = false
+        return success
     }
 
-    fun sidechain_append(buf: ByteArray, blbt_ndx: Int) {
-        Log.d("repo", "sidechain append")
-        val b = context.tinyDemux.chkt[blbt_ndx]
-        val f = _openFile(b.fid!!, "rw", b.seq,1)
-        f.seek(f.length())
-        f.write(buf)
-        f.close()
-        var i = TINYSSB_PKT_LEN - HASH_LEN - 1 // are we at the end of the chain_?
-        while (i < TINYSSB_PKT_LEN) // check for a all-zero-hash
-            if (buf[i++].toInt() != 0)
+    fun mk_logEntry(buf: ByteArray): Int {
+        val r = fid2replica(context.idStore.identity.verifyKey)
+        if (r == null)
+            return -1
+        return r.write(buf)
+    }
+
+    fun sidechain_append(buf: ByteArray, fid:ByteArray, seq: Int): Boolean {
+        val r = fid2replica(fid)
+        if (r == null)
+            return false
+        return r.ingest_chunk_pkt(buf, seq)
+    }
+
+    fun mk_want_vect(): ByteArray? {
+        want_is_valid = false // not implemented yet
+        if (want_is_valid) return null
+
+        val lst = ArrayList<Int>()
+        var v = ""
+        var encoding_len = Bipf.encodingLength(want_offs)
+
+        lst.add(want_offs)
+        var i = 0
+        while (i < context.tinyGoset.keys.size) {
+            val ndx = (want_offs + i) % context.tinyGoset.keys.size
+            val fid = context.tinyGoset.keys[ndx]
+            val r = fid2replica(fid)
+            if (r == null) {
+                i++
+                continue
+            }
+            val (ns, ndmx) = r.get_next_seq()
+            encoding_len += Bipf.encode(Bipf.mkInt(ns))!!.size
+            lst.add(ns)
+            v += (if (v.length == 0) "[ " else " ") + "$ndx.$ns"
+            i++
+            if (encoding_len > 100)
                 break
-        if (i == TINYSSB_PKT_LEN) { // end of chain reached, rename file
-            val ldir = File(File(context.getDir(TINYSSB_DIR, MODE_PRIVATE), FEED_DIR), b.fid!!.toHex())
-            val g = File(ldir, "!" + b.seq.toString())
-            g.renameTo(File(ldir, "-" + b.seq.toString())) // new naming style
-            val (content,mid) = feed_read_content(b.fid!!, b.seq)
-            if (content != null) {
-                val e = LogTinyEntry(b.fid!!, b.seq, mid!!, content)
-                context.wai.sendTinyEventToFrontend(e)
-            }
-        } else { // chain extends, install next chunk handler
-            val h = buf.sliceArray(TINYSSB_PKT_LEN - HASH_LEN..buf.lastIndex)
-            val fct = { chunk: ByteArray, b_ndx: Int -> context.tinyNode.incoming_chunk(chunk,b_ndx) }
-            context.tinyDemux.arm_blb(h, fct, b.fid, b.seq, b.bnr + 1)
         }
-        context.tinyDemux.arm_blb(b.h!!) // remove old BLB handler for this packet
+        want_offs = (want_offs + i + 1) % context.tinyGoset.keys.size
+        want_is_valid = true
+        if(lst.size > 1) {
+            return Bipf.encode(Bipf.mkList(lst))
+        }
+        return null
     }
 
-    fun listFeeds(): Array<ByteArray> {
-        val kset = context.tinyGoset.keys
-        val a = Array<ByteArray>(kset.size) { ByteArray(0) }
-        for (i in 0..a.size-1)
-            a[i] = kset[i]
-        return a
+    fun mk_chnk_vect(): ByteArray? {
+        chnk_is_valid = false // not implemented yet
+        if (chnk_is_valid) return null
+
+        val lst = ArrayList<Any>()
+        var v = ""
+        var encoding_len = Bipf.encodingLength(chnk_offs)
+
+        //lst.add(chnk_offs)
+        var i = 0
+        while (i < context.tinyGoset.keys.size) {
+            val ndx = (chnk_offs + i) % context.tinyGoset.keys.size
+            val fid = context.tinyGoset.keys[ndx]
+            val r = fid2replica(fid)
+            val pending = r?.get_open_chains()
+            if (pending == null || pending.isEmpty()) {
+                i++
+                continue
+            }
+            for ((seq, p) in pending) {
+                val c = arrayListOf(ndx, seq, p.cnr)
+                lst.add(c)
+                Log.d("mk_chnk", "calc encoding len")
+                encoding_len += Bipf.encodingLength(c)
+                v += (if (v.length == 0) "[ " else " ") + "$ndx.$seq.${p.cnr}"
+                if (encoding_len > 100)
+                    break
+            }
+            i++
+            if (encoding_len > 100)
+                break
+            Log.d("mk_chnk", "new feed")
+            chnk_offs = (chnk_offs + i + 1) % context.tinyGoset.keys.size
+
+        }
+        chnk_is_valid = true
+        if (lst.size > 0) {
+            return Bipf.encode(Bipf.mkList(lst))
+        }
+        return null
+    }
+
+    fun listFeeds(): List<ByteArray> {
+        return replicas.map { it -> it.fid }
+    }
+
+    fun feed_read_content(fid: ByteArray, seq: Int): ByteArray? {
+        return fid2replica(fid)?.read(seq)
     }
 }
-
-// eof

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
@@ -155,8 +155,7 @@ class Repo(val context: MainActivity) {
                 break
         }
 
-        want_offs = (want_offs + i + 1) % context.tinyGoset.keys.size
-        want_is_valid = true
+
 
 
         if(lst.size > 1) {
@@ -164,11 +163,13 @@ class Repo(val context: MainActivity) {
             vec = vec.mapIndexed { index, i ->
                 val new_idx =(index + want_offs) % vec.size
                 lst.slice(1 .. lst.lastIndex)[new_idx]}
-
             context.tinyNode.update_progress(vec, "me")
 
             return Bipf.encode(Bipf.mkList(lst))
         }
+
+        want_offs = (want_offs + i + 1) % context.tinyGoset.keys.size
+        want_is_valid = true
         return null
     }
 

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
@@ -11,6 +11,7 @@ import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.DMX_PFX
 import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.FID_LEN
 import nz.scuttlebutt.tremolavossbol.utils.Constants.Companion.TINYSSB_PKT_LEN
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.decodeHex
+import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toBase64
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toByteArray
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toHex
 import nz.scuttlebutt.tremolavossbol.utils.HelperFunctions.Companion.toInt32
@@ -78,6 +79,9 @@ class Repo(val context: MainActivity) {
             want_offs = Random.nextInt(0, context.tinyGoset.keys.size - 1)
             chnk_offs = Random.nextInt(0, context.tinyGoset.keys.size - 1)
         }
+
+        if(context.isWaiInitialized())
+            context.wai.eval("b2f_new_contact(\"@${fid.toBase64()}.ed25519\")") // notify frontend
 
         want_is_valid = false
         chnk_is_valid = false

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/Repo.kt
@@ -194,7 +194,6 @@ class Repo(val context: MainActivity) {
             for ((seq, p) in pending) {
                 val c = arrayListOf(ndx, seq, p.cnr)
                 lst.add(c)
-                Log.d("mk_chnk", "calc encoding len")
                 encoding_len += Bipf.encodingLength(c)
                 v += (if (v.length == 0) "[ " else " ") + "$ndx.$seq.${p.cnr}"
                 if (encoding_len > 100)
@@ -203,7 +202,6 @@ class Repo(val context: MainActivity) {
             i++
             if (encoding_len > 100)
                 break
-            Log.d("mk_chnk", "new feed")
             chnk_offs = (chnk_offs + i + 1) % context.tinyGoset.keys.size
 
         }

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/ble/BlePeers.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/tssb/ble/BlePeers.kt
@@ -176,7 +176,7 @@ class BlePeers(val act: MainActivity) {
                 val rc = act.tinyDemux.on_rx(ch.value)
                 act.ioLock.unlock()
                 if (!rc)
-                    Log.d("ble rx", "not dmx entry for ${ch.value.toHex()}")
+                    Log.d("ble rx", "no dmx entry for ${ch.value.toHex()}")
             }
         }
 


### PR DESCRIPTION
## What?

Added additional frontend callbacks, with different guarantees, to provide more options to handle new received log entries.

## Why?

Previously, there was only one frontend callback, which was called when a logentry was completely received, including its sidechain. However, there were no guarantees about the order in which the log entries were forwarded to the frontend, which may be necessary for some applications (eg. operation-based CRDTs).
Additionally, some applications may respond to sidechains that are not fully loaded, which is also not supported by the callback.

## How?

In addition to the current callback, two new callbacks have been introduced:
One ensures that fully received log entries are forwarded in the causal history of the feed, by tracking which entries have already been forwarded and which ones are still pending, while the second callback is triggered when the log entry is received, but the sidechain has not yet been loaded.

## Testing

Tested with two android smartphones (SDK 29 & 30).
