### PR TITLE
Moving the storage of user settings from the frontend to the backend

### DIFF
--- a/android/tinySSB/app/src/main/assets/web/board_ui.js
+++ b/android/tinySSB/app/src/main/assets/web/board_ui.js
@@ -88,7 +88,7 @@ function load_board_list() {
             var board = tremola.board[bid]
             var date = new Date(bidTimestamp[i][1])
             date = date.toDateString() + ' ' + date.toTimeString().substring(0, 5);
-            if (board.forgotten && tremola.settings.hide_forgotten_boards)
+            if (board.forgotten && tremola.settings.hide_forgotten_kanbans)
                 continue
             var cl, mem, item, bg, row, badge, badgeId, cnt;
             cl = document.getElementById('lst:kanban');

--- a/android/tinySSB/app/src/main/assets/web/tremola.html
+++ b/android/tinySSB/app/src/main/assets/web/tremola.html
@@ -426,7 +426,7 @@
     <div class="settings">
       <div class="settingsText">Connect to Peers via BLE</div>
       <div style="float: right;"><label class="switch">
-        <input id="ble" type="checkbox" onchange="toggle_changed(this);">
+        <input id="ble_enabled" type="checkbox" onchange="toggle_changed(this);">
         <span class="slider round"></span></label></div>
     </div>
     <hr>
@@ -434,7 +434,7 @@
     <div class="settings">
       <div class="settingsText">Connect to Peers via UDP Multicast</div>
       <div><label class="switch">
-        <input id="udp_multicast" type="checkbox" onchange="toggle_changed(this);">
+        <input id="udp_multicast_enabled" type="checkbox" onchange="toggle_changed(this);">
         <span class="slider round"></span>
       </label></div>
     </div>
@@ -443,7 +443,7 @@
     <div class="settings">
       <div class="settingsText">Connect to Pub via Websocket</div>
       <div style="float: right;"><label class="switch">
-        <input id="websocket" type="checkbox" onchange="toggle_changed(this);">
+        <input id="websocket_enabled" type="checkbox" onchange="toggle_changed(this);">
         <span class="slider round"></span></label></div>
     </div>
     <div id="container:settings_ws_url" class="websocket_url_settings" style="display:none;">
@@ -456,7 +456,7 @@
     <div class="settings">
       <div class="settingsText">Preview before sending</div>
       <div style="float: right;"><label class="switch">
-        <input id="enable_preview" type="checkbox" onchange="toggle_changed(this);">
+        <input id="show_chat_preview" type="checkbox" onchange="toggle_changed(this);">
         <span class="slider round"></span></label></div>
     </div>
     <hr>
@@ -472,7 +472,7 @@
     <div class="settings">
       <div class="settingsText">Hide forgotten Kanban Boards</div>
       <div style="float: right;"><label class="switch">
-        <input id="hide_forgotten_boards" type="checkbox" onchange="toggle_changed(this);">
+        <input id="hide_forgotten_kanbans" type="checkbox" onchange="toggle_changed(this);">
         <span class="slider round"></span></label></div>
     </div>
     <hr>
@@ -496,7 +496,7 @@
     <div class="settings">
       <div class="settingsText">Background map</div>
       <div style="float: right;"><label class="switch">
-        <input id="background_map" type="checkbox" onchange="toggle_changed(this);">
+        <input id="show_background_map" type="checkbox" onchange="toggle_changed(this);">
         <span class="slider round"></span></label></div>
     </div>
     <hr>

--- a/android/tinySSB/app/src/main/assets/web/tremola.js
+++ b/android/tinySSB/app/src/main/assets/web/tremola.js
@@ -16,6 +16,7 @@ var colors = ["#d9ceb2", "#99b2b7", "#e6cba5", "#ede3b4", "#8b9e9b", "#bd7578", 
 var curr_img_candidate = null;
 var pubs = []
 var wants = {}
+var loaded_settings = {} // the settings provided bz the backend, will overwrite tremola.settings after initialization
 
 var restream = false // whether the backend is currently restreaming all posts
 
@@ -856,7 +857,7 @@ function resetTremola() { // wipes browser-side content
         "contacts": {},
         "profile": {},
         "id": myId,
-        "settings": get_default_settings(),
+        "settings": {},
         "board": {}
     }
     var n = recps2nm([myId])
@@ -920,63 +921,6 @@ function b2f_ble_disabled() {
     }
     //ble_status = "disabled"
 }
-
-/*
-var want = {} // all received want vectors, id: [[want vector], timestamp], want vectors older than 90 seconds are discarded
-var max_want = [] // current max vector
-var old_curr = [] // own want vector at the time when the maximum want vector was last updated
-
-function b2f_want_update(identifier, wantVector) {
-
-    console.log("b2f received want:", wantVector, "from: ", identifier)
-
-    // remove old want vectors
-    var deleted = false;
-    for (var id in want) {
-        var ts = want[id][1]
-        if(Date.now() - ts > 90000) {
-            console.log("removed want of", id)
-            delete want[id]
-            deleted = true
-        }
-
-    }
-
-    // if the want vector didn't change, no further updates are required
-    if(identifier in want) {
-        if( equalArrays(want[identifier][0], wantVector)) {
-            console.log("update only")
-            want[identifier][1] = Date.now()
-            if(!deleted)  //if a want vector was previously removed, the max_want needs to be recalculated otherwise it is just an update without an effect
-                return
-        }
-    }
-
-    want[identifier] = [wantVector, Date.now()]
-
-    // calculate new max want vector
-    var all_vectors = Object.values(want).map(val => val[0])
-    var new_max_want = all_vectors.reduce((accumulator, curr) => accumulator.len >= curr.len ? accumulator : curr) //return want vector with most entries
-
-    for (var vec of all_vectors) {
-        for(var i in vec) {
-            if (vec[i] > new_max_want[i])
-                new_max_want[i] = vec[i]
-        }
-    }
-
-    // update
-    if (!equalArrays(max_want,new_max_want)) {
-        old_curr = want['me'][0]
-        max_want = new_max_want
-        console.log("new max")
-    }
-
-    refresh_connection_progressbar()
-
-    console.log("max:", max_want)
-}
-*/
 
 function b2f_local_peer_remaining_updates(identifier, remaining) {
     //TODO
@@ -1232,7 +1176,7 @@ function b2f_new_image_blob(ref) {
     overlayIsActive = true;
 }
 
-function b2f_initialize(id) {
+function b2f_initialize(id, settings) {
     myId = id
     if (window.localStorage.tremola) {
         tremola = JSON.parse(window.localStorage.getItem('tremola'));
@@ -1244,11 +1188,13 @@ function b2f_initialize(id) {
     if (tremola == null) {
         resetTremola();
         console.log("reset tremola")
+        if (typeof Android == 'undefined')
+            tremola.settings = BrowserOnlySettings // browser-only testing
     }
     if (typeof Android == 'undefined')
         console.log("loaded ", JSON.stringify(tremola))
-    if (!('settings' in tremola))
-        tremola.settings = {}
+    else
+        tremola.settings = JSON.parse(settings)
     var nm, ref;
     for (nm in tremola.settings)
         setSetting(nm, tremola.settings[nm])
@@ -1260,5 +1206,8 @@ function b2f_initialize(id) {
     setScenario('chats');
     // load_chat("ALL");
 }
+
+
+
 
 // --- eof

--- a/android/tinySSB/app/src/main/assets/web/tremola.js
+++ b/android/tinySSB/app/src/main/assets/web/tremola.js
@@ -1139,6 +1139,11 @@ function b2f_new_event(e) { // incoming SSB log event: we get map with three ent
     }
 }
 
+// backend callback method when calling backend("settings:get")
+function b2f_get_settings(settings) {
+    tremola.settings = settings
+}
+
 function b2f_new_contact(fid) {
     if ((fid in tremola.contacts)) // do not overwrite existing entry
         return

--- a/android/tinySSB/app/src/main/assets/web/tremola_settings.js
+++ b/android/tinySSB/app/src/main/assets/web/tremola_settings.js
@@ -2,20 +2,23 @@
 
 "use strict";
 
-function get_default_settings() {
-    return {
-        'enable_preview': false,
-        'background_map': true,
-        'websocket': true,
-        'show_shortnames': true,
-        'hide_forgotten_conv': true,
-        'hide_forgotten_contacts': true,
-        'udp_multicast': true,
-        'ble': true,
-        'websocket_url': "ws://meet.dmi.unibas.ch:8989"
-    }
+
+// These default settings are only used for browser-only testing
+// Normally, these settings below WILL BE IGNORED and loaded via the provided backend.
+const BrowserOnlySettings = {
+    'show_chat_preview': false,
+    'show_background_map': true,
+    'websocket_enabled': true,
+    'show_shortnames': true,
+    'hide_forgotten_conv': true,
+    'hide_forgotten_contacts': true,
+    'hide_forgotten_kanbans': true,
+    'udp_multicast_enabled': true,
+    'ble_enabled': true,
+    'websocket_url': "ws://meet.dmi.unibas.ch:8989"
 }
 
+// button/toggle handler for boolean settings; settingID is determined by the id of the html object that emitted the event (e.id)
 function toggle_changed(e) {
     // console.log("toggle ", e.id);
     tremola.settings[e.id] = e.checked;
@@ -24,12 +27,14 @@ function toggle_changed(e) {
     applySetting(e.id, e.checked);
 }
 
-function getSetting(nm) {
-    return document.getElementById(nm).checked
+// getter
+function getSetting(settingID) {
+    return tremola.settings[settingID]
 }
 
+// frontend handler when settings have changed
 function applySetting(nm, val) {
-    if (nm == 'background_map') {
+    if (nm == 'show_background_map') {
         if (val)
             document.body.style.backgroundImage = "url('img/splash-as-background.jpg')";
         else
@@ -38,7 +43,7 @@ function applySetting(nm, val) {
         load_chat_list();
     } else if (nm == 'hide_forgotten_contacts') {
         load_contact_list();
-    } else if (nm == 'websocket') {
+    } else if (nm == 'websocket_enabled') {
         if (val)
             document.getElementById("container:settings_ws_url").style.display = 'flex'
         else
@@ -46,8 +51,9 @@ function applySetting(nm, val) {
     }
 }
 
+// setter, this will also save the given settingID and its value in the backend
 function setSetting(nm, val) {
-    // console.log("setting", nm, val)
+    console.log("setting", nm, val)
     if (nm == "websocket_url") {
       document.getElementById("settings_urlInput").value = val
       return
@@ -56,20 +62,13 @@ function setSetting(nm, val) {
     document.getElementById(nm).checked = val;
 }
 
-/* async */
+// calls the backend to wipe everything, including the ID
 function settings_wipe() {
     closeOverlay();
-    backend("wipe"); // will not return
-    /*
-    window.localStorage.setItem("tremola", "null");
-    backend("ready"); // will call initialize()
-    await new Promise(resolve => setTimeout(resolve, 500));
-    // resetTremola();
-    menu_redraw();
-    setScenario('chats');
-    */
+    backend("wipe"); // will not return, because of app restart
 }
 
+// button handler for websocket url textfield
 function btn_setWebsocketUrl() {
    var new_url = document.getElementById("settings_urlInput").value
 

--- a/android/tinySSB/app/src/main/assets/web/tremola_ui.js
+++ b/android/tinySSB/app/src/main/assets/web/tremola_ui.js
@@ -267,7 +267,7 @@ function closeOverlay() {
 function showPreview() {
     var draft = escapeHTML(document.getElementById('draft').value);
     if (draft.length == 0) return;
-    if (!getSetting("enable_preview")) {
+    if (!getSetting("show_chat_preview")) {
         new_text_post(draft);
         return;
     }

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
@@ -43,7 +43,7 @@ class WebAppInterface(val act: MainActivity, val webView: WebView) {
                 (act as MainActivity)._onBackPressed()
             }
             "ready" -> {
-                eval("b2f_initialize(\"${act.idStore.identity.toRef()}\")")
+                eval("b2f_initialize('${act.idStore.identity.toRef()}', '${act.settings!!.getSettings()}')")
                 frontend_ready = true
                 act.tinyRepo.addNumberOfPendingChunks(0) // initialize chunk progress bar
                 act.tinyNode.beacon()
@@ -240,12 +240,7 @@ class WebAppInterface(val act: MainActivity, val webView: WebView) {
                 }
             }
             "settings:set" -> {
-                when(args[1]) {
-                    "ble" -> {act.settings!!.setBleEnabled(args[2].toBooleanStrict())}
-                    "udp_multicast" -> {act.settings!!.setUdpMulticastEnabled(args[2].toBooleanStrict())}
-                    "websocket" -> {act.settings!!.setWebsocketEnabled(args[2].toBooleanStrict())}
-                    "websocket_url" -> {act.settings!!.setWebsocketUrl(args[2])}
-                }
+                act.settings!!.set(args[1], args[2])
             }
             else -> {
                 Log.d("onFrontendRequest", "unknown")

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/WebAppInterface.kt
@@ -242,6 +242,10 @@ class WebAppInterface(val act: MainActivity, val webView: WebView) {
             "settings:set" -> {
                 act.settings!!.set(args[1], args[2])
             }
+            "settings:get" -> {
+                val settings = act.settings!!.getSettings()
+                act.wai.eval("b2f_get_settings('${settings}')")
+            }
             else -> {
                 Log.d("onFrontendRequest", "unknown")
             }

--- a/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/utils/Constants.kt
+++ b/android/tinySSB/app/src/main/java/nz/scuttlebutt/tremolavossbol/utils/Constants.kt
@@ -40,7 +40,7 @@ class Constants{
         val TINYSSB_BLE_RX_NAME_DESCRIPTOR = UUID.fromString("6e400002-7646-4b5b-9a50-71becce51559")
         val TINYSSB_BLE_TX_CHARACTERISTIC = UUID.fromString("6e400003-7646-4b5b-9a50-71becce51558") // for receiving from the remote device
 
-        val TINYSSB_SIMPLEPUB_URL = "ws://meet.dmi.unibas.ch:8080"
+        val TINYSSB_SIMPLEPUB_URL = "ws://meet.dmi.unibas.ch:8989"
 
         val TINYSSB_DIR = "tinyssb"
     }


### PR DESCRIPTION
## What?

This PR shifts the storage of user preferences from the frontend to the backend.

## Why?

Previously, the settings were saved in both the frontend and the backend. In the event of a crash, this could lead to inconsistencies between the user settings displayed in the frontend and the settings implemented in the backend. Therefore, the storage and management of user settings has been moved completely from the frontend to the backend.

## How?

The backend stores all settings in a key-value store, with the key serving as the identifier for each setting and the corresponding value representing its current status. The frontend can modify these settings through backend calls. During initialization, the frontend retrieves the current status of the settings from the backend and can also query the current state of all saved settings at runtime.

## Testing

Tested with two android smartphones (SDK 29 & 30).
